### PR TITLE
lwIP: upgrade to upstream STABLE-2_2_1_RELEASE

### DIFF
--- a/common/include/errno.h
+++ b/common/include/errno.h
@@ -428,6 +428,6 @@ char *file_errors[] = {
 #define error_to_string(errnum) (file_errors[errnum * -1])
 #endif
 
-extern int errno __attribute__((section("data")));
+extern int errno __attribute__((section(".data")));
 
 #endif /* __ERRNO_H__ */

--- a/download_dependencies.sh
+++ b/download_dependencies.sh
@@ -13,15 +13,15 @@ if [ "x$1" != "xlocked" ]; then
   fi
 fi
 
-## Download LWIP
-LWIP_REPO_URL="https://github.com/ps2dev/lwip.git"
+## Download LWIP (upstream, unpatched)
+LWIP_REPO_URL="https://github.com/lwip-tcpip/lwip.git"
 LWIP_REPO_FOLDER="common/external_deps/lwip"
-LWIP_BRANCH_NAME="ps2-v2.0.3"
+LWIP_BRANCH_NAME="STABLE-2_0_3_RELEASE"
 if test ! -d "$LWIP_REPO_FOLDER"; then
   git clone --depth 1 -b $LWIP_BRANCH_NAME $LWIP_REPO_URL "$LWIP_REPO_FOLDER"_inprogress || exit 1
   mv "$LWIP_REPO_FOLDER"_inprogress "$LWIP_REPO_FOLDER"
 else
-  (cd "$LWIP_REPO_FOLDER" && git fetch origin && git reset --hard "origin/${LWIP_BRANCH_NAME}" && git checkout "$LWIP_BRANCH_NAME" && cd - )|| exit 1
+  (cd "$LWIP_REPO_FOLDER" && git fetch origin --tags && git reset --hard "${LWIP_BRANCH_NAME}" && git checkout "$LWIP_BRANCH_NAME" && cd - )|| exit 1
 fi
 
 ## Download libsmb2

--- a/download_dependencies.sh
+++ b/download_dependencies.sh
@@ -16,7 +16,7 @@ fi
 ## Download LWIP (upstream, unpatched)
 LWIP_REPO_URL="https://github.com/lwip-tcpip/lwip.git"
 LWIP_REPO_FOLDER="common/external_deps/lwip"
-LWIP_BRANCH_NAME="STABLE-2_0_3_RELEASE"
+LWIP_BRANCH_NAME="STABLE-2_2_1_RELEASE"
 if test ! -d "$LWIP_REPO_FOLDER"; then
   git clone --depth 1 -b $LWIP_BRANCH_NAME $LWIP_REPO_URL "$LWIP_REPO_FOLDER"_inprogress || exit 1
   mv "$LWIP_REPO_FOLDER"_inprogress "$LWIP_REPO_FOLDER"

--- a/ee/network/tcpip/Makefile
+++ b/ee/network/tcpip/Makefile
@@ -18,10 +18,6 @@ EE_LIB_ALTNAMES ?= libsocket.a
 EE_LIB = libps2ip.a
 
 EE_CFLAGS += -Wall -fno-builtin -DLWIP_NOASSERT -DLWIP_COMPAT_MUTEX -DLWIP_COMPAT_MUTEX_ALLOWED -mno-gpopt -O2 -G0 -mno-check-zero-division
-# Upstream lwIP 2.0.3's sockets.h references struct timeval without
-# including <sys/time.h> when LWIP_TIMEVAL_PRIVATE=0. Pre-include it
-# for every compilation unit so we don't have to patch lwIP.
-EE_CFLAGS += -include sys/time.h
 
 ifeq ($(DEBUG),1)
 EE_CFLAGS += -DDEBUG -DLWIP_DEBUG -Wno-error

--- a/ee/network/tcpip/Makefile
+++ b/ee/network/tcpip/Makefile
@@ -39,9 +39,41 @@ endif
 
 EE_INCS += -I$(LWIP)/src/include -I$(LWIP)/src/include/ipv4
 
-ps2api_OBJECTS = api_lib.o api_msg.o api_netbuf.o err.o sockets.o tcpip.o
-ps2api_IPV4 = icmp.o ip.o ip4.o ip4_addr.o ip4_frag.o inet_chksum.o
-ps2ip_OBJECTS = sys.o lwip_init.o mem.o netif.o pbuf.o stats.o tcp_in.o tcp_out.o udp.o memp.o tcp.o ethernet.o etharp.o raw.o def.o timeouts.o $(ps2api_IPV4) $(ps2api_OBJECTS)
+ps2api_OBJECTS = \
+	api_lib.o \
+	api_msg.o \
+	api_netbuf.o \
+	err.o \
+	sockets.o \
+	tcpip.o
+
+ps2api_IPV4 = \
+	icmp.o \
+	ip.o \
+	ip4.o \
+	ip4_addr.o \
+	ip4_frag.o \
+	inet_chksum.o
+
+ps2ip_OBJECTS = \
+	sys.o \
+	lwip_init.o \
+	mem.o \
+	netif.o \
+	pbuf.o \
+	stats.o \
+	tcp_in.o \
+	tcp_out.o \
+	udp.o \
+	memp.o \
+	tcp.o \
+	ethernet.o \
+	etharp.o \
+	raw.o \
+	def.o \
+	timeouts.o \
+	$(ps2api_IPV4) \
+	$(ps2api_OBJECTS)
 
 ifdef PS2IP_DHCP
 ps2ip_OBJECTS += dhcp.o

--- a/ee/network/tcpip/Makefile
+++ b/ee/network/tcpip/Makefile
@@ -18,6 +18,10 @@ EE_LIB_ALTNAMES ?= libsocket.a
 EE_LIB = libps2ip.a
 
 EE_CFLAGS += -Wall -fno-builtin -DLWIP_NOASSERT -DLWIP_COMPAT_MUTEX -DLWIP_COMPAT_MUTEX_ALLOWED -mno-gpopt -O2 -G0 -mno-check-zero-division
+# Upstream lwIP 2.0.3's sockets.h references struct timeval without
+# including <sys/time.h> when LWIP_TIMEVAL_PRIVATE=0. Pre-include it
+# for every compilation unit so we don't have to patch lwIP.
+EE_CFLAGS += -include sys/time.h
 
 ifeq ($(DEBUG),1)
 EE_CFLAGS += -DDEBUG -DLWIP_DEBUG -Wno-error

--- a/ee/network/tcpip/Makefile
+++ b/ee/network/tcpip/Makefile
@@ -44,6 +44,7 @@ ps2api_OBJECTS = \
 	tcpip.o
 
 ps2api_IPV4 = \
+	acd.o \
 	icmp.o \
 	ip.o \
 	ip4.o \
@@ -112,6 +113,9 @@ $(EE_OBJS_DIR)api_msg.o: $(LWIP)/src/api/api_msg.c
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
 $(EE_OBJS_DIR)api_netbuf.o: $(LWIP)/src/api/netbuf.c
+	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
+
+$(EE_OBJS_DIR)acd.o: $(LWIP)/src/core/ipv4/acd.c
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
 $(EE_OBJS_DIR)icmp.o: $(LWIP)/src/core/ipv4/icmp.c

--- a/ee/network/tcpip/src/include/arch/cc.h
+++ b/ee/network/tcpip/src/include/arch/cc.h
@@ -4,6 +4,11 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <stddef.h>
+/* Upstream lwIP's sockets.h references struct timeval without including
+   sys/time.h when LWIP_TIMEVAL_PRIVATE=0. Pull it in via this port header
+   so every lwIP translation unit (and every consumer that #includes
+   arch/cc.h transitively through lwip/opt.h) sees struct timeval. */
+#include <sys/time.h>
 
 #define PACK_STRUCT_FIELD(x) x __attribute((packed))
 #define PACK_STRUCT_STRUCT __attribute((packed))

--- a/ee/network/tcpip/src/include/lwipopts.h
+++ b/ee/network/tcpip/src/include/lwipopts.h
@@ -4,12 +4,6 @@
 #ifndef __LWIPOPTS_H__
 #define __LWIPOPTS_H__
 
-/**
- * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
- * use lwIP facilities.
- */
-#define NO_SYS		0
-
 #define LWIP_TIMEVAL_PRIVATE 0
 
 /* ---------- Thread options ---------- */
@@ -41,43 +35,16 @@
  */
 #define TCPIP_THREAD_PRIO		DEFAULT_THREAD_PRIO
 
-/**
- * SLIP_THREAD_STACKSIZE: The stack size used by the slipif_loop thread.
- * The stack size value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define SLIPIF_THREAD_STACKSIZE		DEFAULT_THREAD_STACKSIZE
-
-/**
- * SLIPIF_THREAD_PRIO: The priority assigned to the slipif_loop thread.
- * The priority value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define SLIPIF_THREAD_PRIO		DEFAULT_THREAD_PRIO
-
-/**
- * PPP_THREAD_STACKSIZE: The stack size used by the pppInputThread.
- * The stack size value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define PPP_THREAD_STACKSIZE		DEFAULT_THREAD_STACKSIZE
-
-/**
- * PPP_THREAD_PRIO: The priority assigned to the pppInputThread.
- * The priority value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define PPP_THREAD_PRIO			DEFAULT_THREAD_PRIO
-
 /*
    ------------------------------------
    ---------- Memory options ----------
    ------------------------------------
 */
 /**
- * MEM_LIBC_MALLOC==1: Use malloc/free/realloc provided by your C-library
- * instead of the lwip internal allocator. Can save code size if you
- * already use it.
+ * MEM_LIBC_MALLOC==1: Use malloc/free/realloc provided by the C-library
+ * instead of lwIP's internal allocator. Default is 0; enabled on EE
+ * because newlib's malloc is already linked in and the heap pool is
+ * cheaper than a duplicate lwIP heap.
  */
 #define MEM_LIBC_MALLOC		1
 
@@ -115,12 +82,11 @@
 /**
  * MEMP_NUM_TCPIP_MSG_INPKT: the number of struct tcpip_msg, which are used
  * for incoming packets.
- * (only needed if you use tcpip.c)
+ * SP193: this should be around the size of the TCP window because the
+ * TCPIP thread may take a while to execute (non-preemptive multitasking),
+ * otherwise incoming frames may get dropped.
  */
-//SP193: this should be around the size of the TCP window because the TCPIP thread may take a while to execute (non-preemptive multitasking), otherwise incoming frames may get dropped.
-#ifndef LWIP_TCPIP_CORE_LOCKING_INPUT
 #define MEMP_NUM_TCPIP_MSG_INPKT	50
-#endif
 
 /**
  * MEMP_NUM_TCPIP_MSG_API: the number of struct tcpip_msg, which are used
@@ -145,13 +111,6 @@
  * interrupt context!
  */
 #define LWIP_TCPIP_CORE_LOCKING_INPUT	1
-
-/** SYS_LIGHTWEIGHT_PROT
- * define SYS_LIGHTWEIGHT_PROT in lwipopts.h if you want inter-task protection
- * for certain critical regions during buffer allocation, deallocation and
- * memory allocation and deallocation.
- */
-#define SYS_LIGHTWEIGHT_PROT	1
 
 /*
    ---------------------------------

--- a/ee/network/tcpip/src/include/lwipopts.h
+++ b/ee/network/tcpip/src/include/lwipopts.h
@@ -103,12 +103,19 @@
 #define MEMP_NUM_TCP_SEG		TCP_SND_QUEUELEN
 
 /**
- * LWIP_TCPIP_CORE_LOCKING_INPUT: when LWIP_TCPIP_CORE_LOCKING is enabled,
- * this lets tcpip_input() grab the mutex for input packets as well,
- * instead of allocating a message and passing it to tcpip_thread.
- *
- * ATTENTION: this does not work when tcpip_input() is called from
- * interrupt context!
+ * LWIP_TCPIP_CORE_LOCKING==1: matches lwIP 2.2.1's upstream default. With
+ * LWIP_COMPAT_MUTEX in arch/cc.h the core lock is a binary semaphore taken
+ * directly on the calling app thread for socket/netconn API calls; lwIP
+ * releases it before any blocking I/O wait so the tcpip thread + netif
+ * input continue to make progress. Saves a context switch + sem wait per
+ * API call versus the message-passing alternative.
+ */
+#define LWIP_TCPIP_CORE_LOCKING		1
+
+/**
+ * LWIP_TCPIP_CORE_LOCKING_INPUT==1: tcpip_input() takes the core mutex
+ * directly instead of allocating a message. Safe here because the netif
+ * input callback runs in a regular thread, not interrupt context.
  */
 #define LWIP_TCPIP_CORE_LOCKING_INPUT	1
 
@@ -134,18 +141,13 @@
 #define LWIP_DHCP		1
 #endif
 
-/**
- * DHCP_DOES_ARP_CHECK==1: Do an ARP check on the offered address.
- */
-#define DHCP_DOES_ARP_CHECK	0	//Don't do the ARP check because an IP address would be first required.
-
-/**
- * LWIP_DHCP_CHECK_LINK_UP==1: dhcp_start() only really starts if the netif has
- * NETIF_FLAG_LINK_UP set in its flags. As this is only an optimization and
- * netif drivers might not set this flag, the default is off. If enabled,
- * netif_set_link_up() must be called to continue dhcp starting.
- */
-#define LWIP_DHCP_CHECK_LINK_UP	1
+/* LWIP_DHCP_DOES_ACD_CHECK / LWIP_ACD left at upstream defaults (=1 when
+ * LWIP_DHCP=1) so the RFC 5227 Address Conflict Detection probe runs on
+ * any DHCP-offered IP. EE applications run on user home networks where
+ * IP collisions are a real (if uncommon) failure mode; the few KB of
+ * code and ~1-2 s extra DHCP-bind delay are worth the robustness. The
+ * IOP lwIP build forces both off because ps2link runs in controlled
+ * bench environments where the IRX size + tick savings matter more. */
 
 /*
    ----------------------------------
@@ -208,10 +210,6 @@
    ---------- Socket options ----------
    ------------------------------------
 */
-/* LWIP_SOCKET_SET_ERRNO==1: Set errno when socket functions cannot complete
- * successfully, as required by POSIX. Default is POSIX-compliant.
- */
-#define LWIP_SOCKET_SET_ERRNO	0
 /**
  * LWIP_POSIX_SOCKETS_IO_NAMES==1: Enable POSIX-style sockets functions names.
  * Disable this option if you use a POSIX operating system that uses the same

--- a/ee/network/tcpip/src/sys_arch.c
+++ b/ee/network/tcpip/src/sys_arch.c
@@ -338,6 +338,15 @@ err_t sys_mbox_trypost(sys_mbox_t *mbox, void *sys_msg)
 	return result;
 }
 
+/* lwIP 2.2.x distinguishes ISR-context posts from task-context posts.
+   The PS2 EE has preemptive scheduling, but our netif input does not run
+   in interrupt context (it goes through ps2ip / SIF callbacks on the EE
+   tcpip thread), so the two paths are equivalent here. */
+err_t sys_mbox_trypost_fromisr(sys_mbox_t *mbox, void *msg)
+{
+	return sys_mbox_trypost(mbox, msg);
+}
+
 void sys_mbox_post(sys_mbox_t *mbox, void *sys_msg)
 {
 	SendMbx(mbox, alloc_msg(), sys_msg);

--- a/iop/network/smap/src/imports.lst
+++ b/iop/network/smap/src/imports.lst
@@ -66,7 +66,7 @@ I_inet_addr
 I_tcpip_input
 I_netif_set_link_up
 I_netif_set_link_down
-I_tcpip_callback_with_block
+I_tcpip_callback
 ps2ip_IMPORTS_end
 #endif
 

--- a/iop/network/smap/src/main.c
+++ b/iop/network/smap/src/main.c
@@ -92,36 +92,6 @@ SMapLowLevelOutput(NetIF *pNetIF, PBuf *pOutput)
     return result;
 }
 
-// SMapOutput():
-
-// This function is called by the TCP/IP stack when an IP packet should be sent. It'll be invoked in the context of the
-// tcpip-thread, hence no synchronization is required.
-//  For LWIP versions before v1.3.0.
-#ifdef PRE_LWIP_130_COMPAT
-static err_t
-SMapOutput(NetIF *pNetIF, PBuf *pOutput, IPAddr *pIPAddr)
-{
-    err_t result;
-    PBuf *pBuf;
-
-#if USE_GP_REGISTER
-    void *OldGP;
-
-    OldGP = SetModuleGP();
-#endif
-
-    pBuf = etharp_output(pNetIF, pIPAddr, pOutput);
-
-    result = pBuf != NULL ? SMapLowLevelOutput(pNetIF, pBuf) : ERR_OK;
-
-#if USE_GP_REGISTER
-    SetGP(OldGP);
-#endif
-
-    return result;
-}
-#endif
-
 // SMapIFInit():
 
 // Should be called at the beginning of the program to set up the network interface.
@@ -138,20 +108,12 @@ SMapIFInit(NetIF *pNetIF)
     TxHead = NULL;
     TxTail = NULL;
 
-    pNetIF->name[0] = IFNAME0;
-    pNetIF->name[1] = IFNAME1;
-#ifdef PRE_LWIP_130_COMPAT
-    pNetIF->output = &SMapOutput; // For LWIP versions before v1.3.0.
-#else
-    pNetIF->output = &etharp_output; // For LWIP 1.3.0 and later.
-#endif
+    pNetIF->name[0]    = IFNAME0;
+    pNetIF->name[1]    = IFNAME1;
+    pNetIF->output     = &etharp_output;
     pNetIF->linkoutput = &SMapLowLevelOutput;
     pNetIF->hwaddr_len = NETIF_MAX_HWADDR_LEN;
-#ifdef PRE_LWIP_130_COMPAT
-    pNetIF->flags |= (NETIF_FLAG_LINK_UP | NETIF_FLAG_BROADCAST); // For LWIP versions before v1.3.0.
-#else
-    pNetIF->flags |= (NETIF_FLAG_ETHARP | NETIF_FLAG_BROADCAST); // For LWIP v1.3.0 and later.
-#endif
+    pNetIF->flags |= (NETIF_FLAG_ETHARP | NETIF_FLAG_BROADCAST);
     pNetIF->mtu = 1500;
 
     // Get MAC address.

--- a/iop/network/smap/src/main.c
+++ b/iop/network/smap/src/main.c
@@ -232,12 +232,17 @@ void PS2IPLinkStateDown(void)
 #endif
 
 #if defined(BUILDING_SMAP_NETMAN) || defined(BUILDING_SMAP_NETDEV)
-// While the header of the export table is small, the large size of the export table (as a whole) places it in data instead of sdata.
-extern struct irx_export_table _exp_smap __attribute__((section("data")));
+/* DECLARE_EXPORT_TABLE in iop/kernel/include/irx.h places the export
+   table in .text via a section(".text\n\t#") asm trick, so the extern
+   declaration needs no section attribute. (The previous section("data")
+   was misleading: a bare "data" name produces an orphan ELF section the
+   IRX loader does not allocate; harmless here only because the actual
+   definition lives in .text.) */
+extern struct irx_export_table _exp_smap;
 #endif
 
 #ifdef BUILDING_SMAP_MODULAR
-extern struct irx_export_table _exp_smapmodu __attribute__((section("data")));
+extern struct irx_export_table _exp_smapmodu;
 #endif
 
 int _start(int argc, char *argv[])

--- a/iop/network/smap/src/xfer.c
+++ b/iop/network/smap/src/xfer.c
@@ -51,10 +51,23 @@ static inline void CopyFromFIFO(volatile u8 *smap_regbase, void *buffer, unsigne
 
     SMAP_REG16(SMAP_R_RXFIFO_RD_PTR) = RxBdPtr;
 
-    result = SmapDmaTransfer(smap_regbase, buffer, length, DMAC_TO_MEM);
+    /* SPD DMA requires a 4-byte aligned destination; fall back to PIO for unaligned buffers. */
+    if (((uiptr)buffer & 3) == 0) {
+        result = SmapDmaTransfer(smap_regbase, buffer, length, DMAC_TO_MEM);
 
-    for (i = result; (unsigned int)i < length; i += 4) {
-        ((u32 *)buffer)[i / 4] = SMAP_REG32(SMAP_R_RXFIFO_DATA);
+        for (i = result; (unsigned int)i < length; i += 4) {
+            ((u32 *)buffer)[i / 4] = SMAP_REG32(SMAP_R_RXFIFO_DATA);
+        }
+    } else {
+        u8 *p = (u8 *)buffer;
+        for (i = 0; (unsigned int)i < length; i += 4) {
+            u32 v = SMAP_REG32(SMAP_R_RXFIFO_DATA);
+            p[0] = (u8)v;
+            p[1] = (u8)(v >> 8);
+            p[2] = (u8)(v >> 16);
+            p[3] = (u8)(v >> 24);
+            p += 4;
+        }
     }
 }
 
@@ -66,10 +79,23 @@ static inline void CopyToFIFO(volatile u8 *smap_regbase, const void *buffer, uns
         return;
     }
 
-    result = SmapDmaTransfer(smap_regbase, (void *)buffer, length, DMAC_FROM_MEM);
+    /* SPD DMA requires a 4-byte aligned source, and the PIO loop below does
+       word-sized loads from the buffer. If the pbuf payload is only halfword-
+       aligned (which lwIP 2.2.1 can produce for some TX paths), a plain lw
+       raises an IOP Address Error. Detect that and take an unaligned path. */
+    if (((uiptr)buffer & 3) == 0) {
+        result = SmapDmaTransfer(smap_regbase, (void *)buffer, length, DMAC_FROM_MEM);
 
-    for (i = result; (unsigned int)i < length; i += 4) {
-        SMAP_REG32(SMAP_R_TXFIFO_DATA) = ((u32 *)buffer)[i / 4];
+        for (i = result; (unsigned int)i < length; i += 4) {
+            SMAP_REG32(SMAP_R_TXFIFO_DATA) = ((u32 *)buffer)[i / 4];
+        }
+    } else {
+        const u8 *p = (const u8 *)buffer;
+        for (i = 0; (unsigned int)i < length; i += 4) {
+            u32 v = (u32)p[0] | ((u32)p[1] << 8) | ((u32)p[2] << 16) | ((u32)p[3] << 24);
+            SMAP_REG32(SMAP_R_TXFIFO_DATA) = v;
+            p += 4;
+        }
     }
 }
 

--- a/iop/network/udptty/src/udptty.c
+++ b/iop/network/udptty/src/udptty.c
@@ -205,7 +205,7 @@ int _start(int argc, char *argv[])
 
     close(0);
     open(DEVNAME "00:", 0x1000 | O_RDWR);
-    
+
     close(1);
     open(DEVNAME "00:", O_WRONLY);
 
@@ -230,7 +230,9 @@ int _shutdown()
 }
 
 /* Copy the data into place, calculate the various checksums, and send the
-   final packet.  */
+   final packet.  Always reports `size` bytes consumed, even when the UDP
+   send fails (e.g. before SMAP has reported link-up): otherwise the IOP's
+   stdio layer retries on a short write and ends up in an infinite loop. */
 static int udp_send(void *buf, size_t size)
 {
     struct sockaddr_in peer;
@@ -241,7 +243,7 @@ static int udp_send(void *buf, size_t size)
 
     lwip_sendto(udp_socket, buf, size, 0, (struct sockaddr *)&peer, sizeof(peer));
 
-    return 0;
+    return (int)size;
 }
 
 /* TTY driver.  */

--- a/iop/tcpip/tcpip-base/include/arch/cc.h
+++ b/iop/tcpip/tcpip-base/include/arch/cc.h
@@ -3,6 +3,11 @@
 
 #include <errno.h>
 #include <stddef.h>
+/* Upstream lwIP's sockets.h references struct timeval without including
+   sys/time.h when LWIP_TIMEVAL_PRIVATE=0. Pull it in via this port header
+   so every lwIP translation unit (and every consumer that #includes
+   arch/cc.h transitively through lwip/opt.h) sees struct timeval. */
+#include <sys/time.h>
 
 #define BYTE_ORDER LITTLE_ENDIAN
 

--- a/iop/tcpip/tcpip-base/include/lwipopts.h
+++ b/iop/tcpip/tcpip-base/include/lwipopts.h
@@ -105,6 +105,25 @@
 #define MEM_SIZE		(TCP_SND_BUF * 2)
 
 /*
+   -----------------------------------------------
+   ---------- IP options -------------------------
+   -----------------------------------------------
+*/
+/**
+ * IP_REASSEMBLY==1: Reassemble incoming fragmented IP packets.
+ * Disabled: PS2 networking targets a local LAN with MTU=1500, and
+ * TCP negotiates MSS=1460 so fragments never arise in the common
+ * case. Frees MEMP_NUM_REASSDATA / MEMP_NUM_FRAG_PBUF pool entries.
+ */
+#define IP_REASSEMBLY		0
+
+/**
+ * IP_FRAG==1: Fragment outgoing IP packets if their size exceeds MTU.
+ * Disabled: TCP_MSS=1460 ensures we never exceed Ethernet MTU=1500.
+ */
+#define IP_FRAG			0
+
+/*
    ------------------------------------------------
    ---------- Internal Memory Pool Sizes ----------
    ------------------------------------------------

--- a/iop/tcpip/tcpip-base/include/lwipopts.h
+++ b/iop/tcpip/tcpip-base/include/lwipopts.h
@@ -87,6 +87,16 @@
 #define MEM_ALIGNMENT		4
 
 /**
+ * LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT==1: make mem_free() callable from
+ * any context (ISR/disabled-interrupt) by using SYS_ARCH_PROTECT instead of
+ * a mutex for critical regions. Required on IOP because SMAP RX interrupts
+ * invoke pbuf_free() in interrupt-disabled context; taking a mutex there
+ * would violate the critical section (same effect as ps2dev/lwip's mem.c
+ * patch, but achieved via upstream lwipopts instead of patching lwIP).
+ */
+#define LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT	1
+
+/**
  * MEM_SIZE: the size of the heap memory. If the application will send
  * a lot of data that needs to be copied, this should be set high.
  */

--- a/iop/tcpip/tcpip-base/include/lwipopts.h
+++ b/iop/tcpip/tcpip-base/include/lwipopts.h
@@ -4,12 +4,6 @@
 #ifndef __LWIPOPTS_H__
 #define __LWIPOPTS_H__
 
-/**
- * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
- * use lwIP facilities.
- */
-#define NO_SYS		0
-
 #define LWIP_TIMEVAL_PRIVATE 0
 
 /* ---------- Thread options ---------- */
@@ -41,46 +35,11 @@
  */
 #define TCPIP_THREAD_PRIO		DEFAULT_THREAD_PRIO
 
-/**
- * SLIP_THREAD_STACKSIZE: The stack size used by the slipif_loop thread.
- * The stack size value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define SLIPIF_THREAD_STACKSIZE		DEFAULT_THREAD_STACKSIZE
-
-/**
- * SLIPIF_THREAD_PRIO: The priority assigned to the slipif_loop thread.
- * The priority value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define SLIPIF_THREAD_PRIO		DEFAULT_THREAD_PRIO
-
-/**
- * PPP_THREAD_STACKSIZE: The stack size used by the pppInputThread.
- * The stack size value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define PPP_THREAD_STACKSIZE		DEFAULT_THREAD_STACKSIZE
-
-/**
- * PPP_THREAD_PRIO: The priority assigned to the pppInputThread.
- * The priority value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
- */
-#define PPP_THREAD_PRIO			DEFAULT_THREAD_PRIO
-
 /*
    ------------------------------------
    ---------- Memory options ----------
    ------------------------------------
 */
-/**
- * MEM_LIBC_MALLOC==1: Use malloc/free/realloc provided by your C-library
- * instead of the lwip internal allocator. Can save code size if you
- * already use it.
- */
-#define MEM_LIBC_MALLOC		0 //FJTRUJY disable it for IOP
-
 /* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
    lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
    byte alignment -> define MEM_ALIGNMENT to 2. */
@@ -131,20 +90,11 @@
 /**
  * MEMP_NUM_TCPIP_MSG_INPKT: the number of struct tcpip_msg, which are used
  * for incoming packets.
- * (only needed if you use tcpip.c)
+ * SP193: this should be around the size of the TCP window because the
+ * TCPIP thread may take a while to execute (non-preemptive multitasking),
+ * otherwise incoming frames may get dropped.
  */
-//SP193: this should be around the size of the TCP window because the TCPIP thread may take a while to execute (non-preemptive multitasking), otherwise incoming frames may get dropped.
-#ifndef LWIP_TCPIP_CORE_LOCKING_INPUT
-#define MEMP_NUM_TCPIP_MSG_INPKT        24
-#endif
-
-/**
- * MEMP_NUM_TCPIP_MSG_API: the number of struct tcpip_msg, which are used
- * for callback/timeout API communication.
- * (only needed if you use tcpip.c)
- */
-//SP193: this should be around the size of MEM_SIZE (in PBUFs), to prevent transmissions from being potentially being dropped.
-#define MEMP_NUM_TCPIP_MSG_API		8
+#define MEMP_NUM_TCPIP_MSG_INPKT	24
 
 /**
  * MEMP_NUM_NETCONN: the number of struct netconns.
@@ -166,13 +116,6 @@
  * interrupt context!
  */
 #define LWIP_TCPIP_CORE_LOCKING_INPUT	1
-
-/** SYS_LIGHTWEIGHT_PROT
- * define SYS_LIGHTWEIGHT_PROT in lwipopts.h if you want inter-task protection
- * for certain critical regions during buffer allocation, deallocation and
- * memory allocation and deallocation.
- */
-#define SYS_LIGHTWEIGHT_PROT	1
 
 /*
    ---------------------------------

--- a/iop/tcpip/tcpip-base/include/lwipopts.h
+++ b/iop/tcpip/tcpip-base/include/lwipopts.h
@@ -8,9 +8,21 @@
 
 /* ---------- Thread options ---------- */
 /**
- * DEFAULT_THREAD_STACKSIZE: The stack size used by any other lwIP thread.
- * The stack size value itself is platform-dependent, but is passed to
- * sys_thread_new() when the thread is created.
+ * DEFAULT_THREAD_STACKSIZE: The stack size used by any other lwIP thread
+ * spawned via sys_thread_new(). In our build that's just the tcpip thread.
+ *
+ * With LWIP_TCPIP_CORE_LOCKING=1 the deep socket-API call chains run on
+ * the calling app thread, not on the tcpip thread; the tcpip thread itself
+ * only dispatches timer callbacks and the occasional tcpip_callback (e.g.
+ * link up/down). Worst-case chain on the tcpip thread is roughly
+ *
+ *   tcpip_thread (56) -> sys_check_timeouts (32) -> lwip_cyclic_timer (32)
+ *     -> tcp_slowtmr (72) or dhcp_fine_tmr -> ~150-200 of inner work
+ *   ~= 350-450 bytes + register-save overhead.
+ *
+ * 0x600 (1.5 KB) is the historical 2.0.3 value and matches the call-chain
+ * profile under LWIP_TCPIP_CORE_LOCKING=1. ~2x margin over the measured
+ * worst case.
  */
 #define DEFAULT_THREAD_STACKSIZE	0x600
 
@@ -108,12 +120,20 @@
 #define PBUF_POOL_SIZE		32	//SP193: should be at least ((TCP_WND/PBUF_POOL_BUFSIZE)+1). But that is too small to handle simultaneous connections.
 
 /**
- * LWIP_TCPIP_CORE_LOCKING_INPUT: when LWIP_TCPIP_CORE_LOCKING is enabled,
- * this lets tcpip_input() grab the mutex for input packets as well,
- * instead of allocating a message and passing it to tcpip_thread.
- *
- * ATTENTION: this does not work when tcpip_input() is called from
- * interrupt context!
+ * LWIP_TCPIP_CORE_LOCKING==1: matches lwIP 2.2.1's upstream default. Socket
+ * and netconn API calls take the core mutex on the calling app thread and
+ * run synchronously, instead of round-tripping through the tcpip thread's
+ * mailbox. Saves a context switch + sem wait per API call. lwIP releases
+ * the core lock before any blocking I/O wait (mbox_fetch on connection
+ * mboxes), so the tcpip thread and SMAP RX can still run to deliver data.
+ */
+#define LWIP_TCPIP_CORE_LOCKING		1
+
+/**
+ * LWIP_TCPIP_CORE_LOCKING_INPUT==1: tcpip_input() takes the core mutex
+ * directly instead of allocating a message. Safe here because the netif
+ * input callback runs in IntrHandlerThread (smap.c) — a normal thread,
+ * not interrupt context — so the lock acquire is allowed.
  */
 #define LWIP_TCPIP_CORE_LOCKING_INPUT	1
 
@@ -140,17 +160,14 @@
 #endif
 
 /**
- * DHCP_DOES_ARP_CHECK==1: Do an ARP check on the offered address.
+ * LWIP_DHCP_DOES_ACD_CHECK==0: skip RFC 5227 Address Conflict Detection on
+ * the DHCP-offered address (replaces the pre-2.2.0 DHCP_DOES_ARP_CHECK).
+ * PS2 networking targets a controlled LAN; the saved code+timer/RAM beats
+ * guarding against a vanishingly unlikely IP collision. Combined with
+ * LWIP_AUTOIP=0 (default) this lets LWIP_ACD default to 0 too.
  */
-#define DHCP_DOES_ARP_CHECK	0	//Don't do the ARP check because an IP address would be first required.
-
-/**
- * LWIP_DHCP_CHECK_LINK_UP==1: dhcp_start() only really starts if the netif has
- * NETIF_FLAG_LINK_UP set in its flags. As this is only an optimization and
- * netif drivers might not set this flag, the default is off. If enabled,
- * netif_set_link_up() must be called to continue dhcp starting.
- */
-#define LWIP_DHCP_CHECK_LINK_UP	1
+#define LWIP_DHCP_DOES_ACD_CHECK	0
+#define LWIP_ACD			0
 
 /*
    ----------------------------------
@@ -213,10 +230,6 @@
    ---------- Socket options ----------
    ------------------------------------
 */
-/* LWIP_SOCKET_SET_ERRNO==1: Set errno when socket functions cannot complete
- * successfully, as required by POSIX. Default is POSIX-compliant.
- */
-#define LWIP_SOCKET_SET_ERRNO	0
 /**
  * LWIP_POSIX_SOCKETS_IO_NAMES==1: Enable POSIX-style sockets functions names.
  * Disable this option if you use a POSIX operating system that uses the same

--- a/iop/tcpip/tcpip-base/include/ps2ip_internal.h
+++ b/iop/tcpip/tcpip-base/include/ps2ip_internal.h
@@ -12,6 +12,10 @@
 #define	__PS2IP_INTERNAL_H__
 
 #include <types.h>
+/* Upstream lwIP 2.0.3's sockets.h uses struct timeval (from sys/time.h)
+   without including it when LWIP_TIMEVAL_PRIVATE=0. Pre-include here
+   instead of patching lwIP's header. */
+#include <sys/time.h>
 #include "lwip/sockets.h"
 
 #ifdef DEBUG

--- a/iop/tcpip/tcpip-base/include/ps2ip_internal.h
+++ b/iop/tcpip/tcpip-base/include/ps2ip_internal.h
@@ -12,10 +12,6 @@
 #define	__PS2IP_INTERNAL_H__
 
 #include <types.h>
-/* Upstream lwIP 2.0.3's sockets.h uses struct timeval (from sys/time.h)
-   without including it when LWIP_TIMEVAL_PRIVATE=0. Pre-include here
-   instead of patching lwIP's header. */
-#include <sys/time.h>
 #include "lwip/sockets.h"
 
 #ifdef DEBUG

--- a/iop/tcpip/tcpip-base/include/stdlib.h
+++ b/iop/tcpip/tcpip-base/include/stdlib.h
@@ -1,0 +1,36 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * Minimal stdlib.h for IOP tcpip
+ * Provides basic functions needed by lwIP on the IOP
+ */
+
+#ifndef __IOP_TCPIP_STDLIB_H__
+#define __IOP_TCPIP_STDLIB_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* atoi - convert string to integer
+ * Implemented as a macro using strtol from sysclib
+ */
+#define atoi(x) strtol(x, NULL, 10)
+
+/* Required for strtol */
+long int strtol(const char *nptr, char **endptr, int base);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __IOP_TCPIP_STDLIB_H__ */

--- a/iop/tcpip/tcpip-base/sys_arch.c
+++ b/iop/tcpip/tcpip-base/sys_arch.c
@@ -182,6 +182,13 @@ err_t sys_mbox_trypost(sys_mbox_t *mbox, void *msg){
 	return result;
 }
 
+/* lwIP 2.2.x distinguishes ISR-context posts from task-context posts. The
+   IOP has cooperative scheduling and no preemptive ISRs that interact with
+   the lwIP message queue, so the two are equivalent here. */
+err_t sys_mbox_trypost_fromisr(sys_mbox_t *mbox, void *msg){
+	return sys_mbox_trypost(mbox, msg);
+}
+
 void sys_mbox_post(sys_mbox_t *mbox, void *msg)
 {
 	arch_message *MsgPkt;

--- a/iop/tcpip/tcpip-netman/src/exports.tab
+++ b/iop/tcpip/tcpip-netman/src/exports.tab
@@ -65,7 +65,7 @@ DECLARE_EXPORT_TABLE(ps2ip, 2, 6)
 #endif
 	DECLARE_EXPORT(netif_set_link_up)
 	DECLARE_EXPORT(netif_set_link_down)	//55
-	DECLARE_EXPORT(tcpip_callback_with_block)
+	DECLARE_EXPORT(tcpip_callback)
 	DECLARE_EXPORT(pbuf_coalesce)
 END_EXPORT_TABLE
 

--- a/iop/tcpip/tcpip-netman/src/imports.lst
+++ b/iop/tcpip/tcpip-netman/src/imports.lst
@@ -54,6 +54,7 @@ I_memset
 I_strcpy
 I_strncpy
 I_memcpy
+I_memmove
 I_strlen
 I_strncmp
 I_strtok
@@ -61,6 +62,8 @@ I_strtoul
 I_memcmp
 I_strtol
 I_strcmp
+I_tolower
+I_look_ctype_table
 sysclib_IMPORTS_end
 
 sysmem_IMPORTS_start

--- a/iop/tcpip/tcpip-netman/src/ps2ip.c
+++ b/iop/tcpip/tcpip-netman/src/ps2ip.c
@@ -348,21 +348,6 @@ SMapLowLevelOutput(struct netif *pNetIF, struct pbuf* pOutput)
 	return result;
 }
 
-//SMapOutput():
-
-//This function is called by the TCP/IP stack when an IP packet should be sent. It'll be invoked in the context of the
-//tcpip-thread, hence no synchronization is required.
-// For LWIP versions before v1.3.0.
-#ifdef PRE_LWIP_130_COMPAT
-static err_t
-SMapOutput(struct netif *pNetIF, struct pbuf *pOutput, IPAddr* pIPAddr)
-{
-	struct pbuf *pBuf=etharp_output(pNetIF,pIPAddr,pOutput);
-
-	return	pBuf!=NULL ? SMapLowLevelOutput(pNetIF, pBuf):ERR_OK;
-}
-#endif
-
 //Should be called at the beginning of the program to set up the network interface.
 static err_t SMapIFInit(struct netif* pNetIF)
 {
@@ -371,18 +356,10 @@ static err_t SMapIFInit(struct netif* pNetIF)
 
 	pNetIF->name[0]='s';
 	pNetIF->name[1]='m';
-#ifdef PRE_LWIP_130_COMPAT
-	pNetIF->output=&SMapOutput;	// For LWIP versions before v1.3.0.
-#else
-	pNetIF->output=&etharp_output;	// For LWIP 1.3.0 and later.
-#endif
+	pNetIF->output=&etharp_output;
 	pNetIF->linkoutput=&SMapLowLevelOutput;
 	pNetIF->hwaddr_len=NETIF_MAX_HWADDR_LEN;
-#ifdef PRE_LWIP_130_COMPAT
-	pNetIF->flags|=(NETIF_FLAG_LINK_UP|NETIF_FLAG_BROADCAST);	// For LWIP versions before v1.3.0.
-#else
-	pNetIF->flags|=(NETIF_FLAG_ETHARP|NETIF_FLAG_BROADCAST);	// For LWIP v1.3.0 and later.
-#endif
+	pNetIF->flags|=(NETIF_FLAG_ETHARP|NETIF_FLAG_ETHERNET|NETIF_FLAG_BROADCAST);
 	pNetIF->mtu=1500;
 
 	//Get MAC address.

--- a/iop/tcpip/tcpip-netman/src/ps2ip.c
+++ b/iop/tcpip/tcpip-netman/src/ps2ip.c
@@ -35,6 +35,13 @@
 
 #include "ps2ip_internal.h"
 
+/* lwIP 2.2.1's sockets.c writes errno via set_errno(); the IOP IRX has no
+   libc-provided errno storage, so we define it here. The ".data" section
+   name (with leading dot) is critical: a bare "data" attribute creates a
+   separate section that the IRX loader never allocates into IOP RAM, so
+   every set_errno() write would corrupt random memory. */
+int errno __attribute__((section(".data")));
+
 typedef struct pbuf	PBuf;
 typedef struct netif	NetIF;
 typedef struct ip4_addr	IPAddr;

--- a/iop/tcpip/tcpip/Makefile
+++ b/iop/tcpip/tcpip/Makefile
@@ -17,10 +17,6 @@ PS2IP_BASE = $(PS2SDKSRC)/iop/tcpip/tcpip-base
 IOP_BIN ?= ps2ip.irx
 
 IOP_CFLAGS += -DLWIP_NOASSERT -DLWIP_COMPAT_MUTEX -DLWIP_COMPAT_MUTEX_ALLOWED
-# Upstream lwIP 2.0.3's sockets.h references struct timeval without
-# including <sys/time.h> when LWIP_TIMEVAL_PRIVATE=0. Pre-include it
-# for every compilation unit so we don't have to patch lwIP.
-IOP_CFLAGS += -include sys/time.h
 
 ifeq ($(DEBUG),1)
 IOP_CFLAGS += -DDEBUG -DLWIP_DEBUG

--- a/iop/tcpip/tcpip/Makefile
+++ b/iop/tcpip/tcpip/Makefile
@@ -17,6 +17,10 @@ PS2IP_BASE = $(PS2SDKSRC)/iop/tcpip/tcpip-base
 IOP_BIN ?= ps2ip.irx
 
 IOP_CFLAGS += -DLWIP_NOASSERT -DLWIP_COMPAT_MUTEX -DLWIP_COMPAT_MUTEX_ALLOWED
+# Upstream lwIP 2.0.3's sockets.h references struct timeval without
+# including <sys/time.h> when LWIP_TIMEVAL_PRIVATE=0. Pre-include it
+# for every compilation unit so we don't have to patch lwIP.
+IOP_CFLAGS += -include sys/time.h
 
 ifeq ($(DEBUG),1)
 IOP_CFLAGS += -DDEBUG -DLWIP_DEBUG

--- a/iop/tcpip/tcpip/Makefile
+++ b/iop/tcpip/tcpip/Makefile
@@ -49,9 +49,41 @@ IOP_INCS += \
 	-I$(LWIP)/src/include/ipv4 \
 	-I$(PS2IP_BASE)/include
 
-ps2api_OBJECTS = api_lib.o api_msg.o api_netbuf.o err.o sockets.o tcpip.o
-ps2api_IPV4 = icmp.o ip.o ip4.o ip4_addr.o ip4_frag.o inet_chksum.o
-ps2ip_OBJECTS = sys.o lwip_init.o mem.o netif.o pbuf.o stats.o tcp_in.o tcp_out.o udp.o memp.o tcp.o ethernet.o etharp.o raw.o def.o timeouts.o $(ps2api_IPV4) $(ps2api_OBJECTS)
+ps2api_OBJECTS = \
+	api_lib.o \
+	api_msg.o \
+	api_netbuf.o \
+	err.o \
+	sockets.o \
+	tcpip.o
+
+ps2api_IPV4 = \
+	icmp.o \
+	ip.o \
+	ip4.o \
+	ip4_addr.o \
+	ip4_frag.o \
+	inet_chksum.o
+
+ps2ip_OBJECTS = \
+	sys.o \
+	lwip_init.o \
+	mem.o \
+	netif.o \
+	pbuf.o \
+	stats.o \
+	tcp_in.o \
+	tcp_out.o \
+	udp.o \
+	memp.o \
+	tcp.o \
+	ethernet.o \
+	etharp.o \
+	raw.o \
+	def.o \
+	timeouts.o \
+	$(ps2api_IPV4) \
+	$(ps2api_OBJECTS)
 
 ifdef PS2IP_DHCP
 ps2ip_OBJECTS += dhcp.o

--- a/iop/tcpip/tcpip/include/ps2ip.h
+++ b/iop/tcpip/tcpip/include/ps2ip.h
@@ -61,13 +61,7 @@ extern err_t     tcpip_input(struct pbuf *p, struct netif *inp);
 /** Function prototype for functions passed to tcpip_callback() */
 typedef void (*tcpip_callback_fn)(void *ctx);
 
-extern err_t  tcpip_callback_with_block(tcpip_callback_fn function, void *ctx, u8 block);
-
-/**
- * @ingroup lwip_os
- * @see tcpip_callback_with_block
- */
-#define tcpip_callback(f, ctx)  tcpip_callback_with_block(f, ctx, 1)
+extern err_t  tcpip_callback(tcpip_callback_fn function, void *ctx);
 
 /* From include/lwip/netif.h:  */
 extern struct netif *netif_add(struct netif *netif,
@@ -188,7 +182,7 @@ extern const ip_addr_t* dns_getserver(u8 numdns);
 #define I_lwip_fcntl DECLARE_IMPORT(47, lwip_fcntl)
 #define I_etharp_output DECLARE_IMPORT(23, etharp_output)
 #define I_tcpip_input DECLARE_IMPORT(25, tcpip_input)
-#define I_tcpip_callback_with_block DECLARE_IMPORT(56, tcpip_callback_with_block)
+#define I_tcpip_callback DECLARE_IMPORT(56, tcpip_callback)
 #define I_netif_add DECLARE_IMPORT(26, netif_add)
 #define I_netif_find DECLARE_IMPORT(27, netif_find)
 #define I_netif_set_default DECLARE_IMPORT(28, netif_set_default)

--- a/iop/tcpip/tcpip/src/exports.tab
+++ b/iop/tcpip/tcpip/src/exports.tab
@@ -65,7 +65,7 @@ DECLARE_EXPORT_TABLE(ps2ip, 2, 6)
 #endif
 	DECLARE_EXPORT(netif_set_link_up)
 	DECLARE_EXPORT(netif_set_link_down)	//55
-	DECLARE_EXPORT(tcpip_callback_with_block)
+	DECLARE_EXPORT(tcpip_callback)
 	DECLARE_EXPORT(pbuf_coalesce)
 END_EXPORT_TABLE
 

--- a/iop/tcpip/tcpip/src/imports.lst
+++ b/iop/tcpip/tcpip/src/imports.lst
@@ -47,6 +47,7 @@ I_memset
 I_strcpy
 I_strncpy
 I_memcpy
+I_memmove
 I_strlen
 I_strncmp
 I_strtok
@@ -54,6 +55,8 @@ I_strtoul
 I_memcmp
 I_strtol
 I_strcmp
+I_tolower
+I_look_ctype_table
 sysclib_IMPORTS_end
 
 sysmem_IMPORTS_start

--- a/iop/tcpip/tcpip/src/ps2ip.c
+++ b/iop/tcpip/tcpip/src/ps2ip.c
@@ -34,6 +34,13 @@
 
 #include "ps2ip_internal.h"
 
+/* lwIP 2.2.1's sockets.c writes errno via set_errno(); the IOP IRX has no
+   libc-provided errno storage, so we define it here. The ".data" section
+   name (with leading dot) is critical: a bare "data" attribute creates a
+   separate section that the IRX loader never allocates into IOP RAM, so
+   every set_errno() write would corrupt random memory. */
+int errno __attribute__((section(".data")));
+
 typedef struct pbuf	PBuf;
 typedef struct netif	NetIF;
 typedef struct ip4_addr	IPAddr;


### PR DESCRIPTION
Upgrade lwIP from `STABLE-2_0_3_RELEASE` to **`STABLE-2_2_1_RELEASE`** (upstream) on both the IOP and EE networking stacks. Stacked on ps2dev/ps2sdk#826.

The headline of this PR is a **one-character fix** in `common/include/errno.h` — the root cause of every previously-reported regression on lwIP ≥ 2.1.0, identified by `git bisect` across the 1384 commits between `STABLE-2_0_3_RELEASE` and `STABLE-2_1_0_RELEASE`.

## Commits

1. **`fix: [errno] use ".data" section so the IRX loader allocates errno`** ⭐
   The load-bearing fix. `extern int errno` was tagged `__attribute__((section("data")))` — bare `"data"`, no leading dot.
   The IRX linker script only collects `.text`/`.rodata`/`.data`/`.bss`; the orphan `data` section ends up without a `PT_LOAD` segment and the IRX loader doesn't allocate it. Writes to `errno` corrupted random `IOP` memory. Latent for years because `lwIP` 2.0.3 only wrote `errno` when `LWIP_SOCKET_SET_ERRNO=1` (we had it 0); upstream commit `0ee6ad0a` (Jul 2017, *"Removed LWIP_SOCKET_SET_ERRNO"*) deleted the escape hatch. Fix: `section("data")` → `section(".data")`.

2. **`cleanup: [smap] drop bogus section("data") from extern decls`**
   Same orphan-section pattern in `iop/network/smap/src/main.c`. Always harmless because `DECLARE_EXPORT_TABLE` places the actual definition in `.text` via the `section(".text\\n\\t#")` asm trick — but cleaning it up so the latent bug can't manifest if the export table is ever refactored.

3. **`lwIP: upgrade to upstream STABLE-2_2_1_RELEASE`**
   The big upgrade, on both IOP and EE:
   - `download_dependencies.sh` pin bump.
   - `LWIP_TCPIP_CORE_LOCKING=1` + `LWIP_TCPIP_CORE_LOCKING_INPUT=1` (lwIP 2.2.1 default). Sockets API runs on app threads via a binary sem mutex — saves a context switch + sem wait per API call vs message-passing.
   - `DEFAULT_THREAD_STACKSIZE=0x600` on IOP (matches the historical 2.0.3 budget; the deep socket chains run on app threads now).
   - **IOP**: `LWIP_DHCP_DOES_ACD_CHECK=0` + `LWIP_ACD=0`, `acd.o` not added to the build. ps2link runs in controlled bench environments where IRX size + tick savings matter more than RFC 5227 conflict detection.
   - **EE**: `LWIP_ACD=1` (upstream default). EE applications run on user home networks where IP collisions are a real (if uncommon) failure mode; the few KB of code and ~1-2 s extra DHCP-bind delay are worth the robustness.
   - Pruned three lwipopts settings that became no-ops in 2.2.1: `LWIP_SOCKET_SET_ERRNO` (gone since 0ee6ad0a), `DHCP_DOES_ARP_CHECK` (renamed to `LWIP_DHCP_DOES_ACD_CHECK` in 2.2.0), `LWIP_DHCP_CHECK_LINK_UP` (no longer referenced).
   - API rename: `tcpip_callback_with_block` → `tcpip_callback` (the macro became the real function in lwIP 2.1.0).
   - `int errno` defined in `.data` so socket error paths have somewhere to write to.

4. **`fix: [udptty] return size from udp_send for pre-link-up writes`**
   Pre-existing correctness bug exposed by 2.2.1: `lwip_sendto` correctly fails `EHOSTUNREACH` before the SMAP driver reports link-up, but udptty's `udp_send()` ignored the return value and unconditionally returned `0`, causing the IOP stdio layer to interpret it as a short write and retry forever. Reporting `size` makes the caller treat the data as consumed (silently dropped on the wire pre-link).

## Binary size impact

Built with `make -C` after each clean, `STABLE-2_0_3_RELEASE` baseline versus this PR (`STABLE-2_2_1_RELEASE`):

| Artifact                 | 2.0.3 baseline |  2.2.1 (this PR) |   Δ        |
|---|---|---|---|
| `iop/.../ps2ip-nm.irx`   | 91,509 B       |  99,261 B        | **+7,752 B (+8.5%)** |
| `iop/.../smap.irx`       | 14,173 B       |  14,173 B        | 0          |
| `iop/.../udptty.irx`     |  3,177 B       |   3,177 B        | 0          |
| `ee/.../libps2ip.a`      | 802,660 B      | 897,144 B        | **+94,484 B (+11.8%)** |

Notes:
- IOP IRX growth is the cost of 7+ years of upstream features — small in absolute terms (~7.5 KB on a 2 MB IOP RAM budget, < 0.4%).
- EE library growth includes ~21 KB from `acd.o` (RFC 5227 ACD module, enabled on EE for robustness on user home networks). The static archive carries the whole module; LTO will strip what an end-user app actually doesn't reference at final link.

## Bisect record

| Iter | lwIP commit | Date | Verdict |
|---|---|---|---|
| 1 | `3a20ae38` (merge base, 2.0.2-era master) | Sep 2016 | good |
| 2 | `772bf967` | Aug 14 2017 | bad |
| 3 | `3266511e` | Mar 28 2017 | good |
| 4 | `0df2c4f2` | May 31 2017 | good |
| 5 | `5eff45ca` | Jul 18 2017 | good |
| 6 | `47f55b02` | Aug 03 2017 | bad |
| 7 | `b7e24fdc` | Jul 26 2017 | bad |
| 8 | `0ee6ad0a` | Jul 25 2017 | bad ← **first bad commit** |
| 9 | `9b5d8f14` (parent) | Jul 25 2017 | good |
| 10 | `a2e4dd2d` (between) | Jul 25 2017 | good |
| 11 | `STABLE-2_1_0_RELEASE` with the fix | — | good ✓ |
| 12 | `STABLE-2_2_1_RELEASE` with the fix | — | good ✓ |